### PR TITLE
Custom translations

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -32,6 +32,7 @@ group :development, :test do
   gem 'coveralls', require: false
   gem 'rspec-rails'
   gem 'shoulda-matchers', git: 'https://github.com/thoughtbot/shoulda-matchers.git', branch: 'rails-5'
+  gem 'shoulda-callback-matchers'
   gem 'cucumber-rails', require: false
   gem 'launchy'
   gem 'pry-byebug'

--- a/Gemfile
+++ b/Gemfile
@@ -24,6 +24,9 @@ gem 'paperclip', '~> 5.0.0'
 gem 'aws-sdk', '~> 2.10', '>= 2.10.27'
 gem 'prawn-rails'
 
+# Active Record Translations
+gem 'i18n-active_record', require: 'i18n/active_record'
+
 group :development, :test do
   gem 'factory_girl_rails'
   gem 'coveralls', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -167,6 +167,8 @@ GEM
     hashery (2.1.2)
     htmlentities (4.3.4)
     i18n (0.8.6)
+    i18n-active_record (0.2.0)
+      i18n (>= 0.5.0)
     inherited_resources (1.7.2)
       actionpack (>= 3.2, < 5.2.x)
       has_scope (~> 0.6)
@@ -400,6 +402,7 @@ DEPENDENCIES
   dotenv-rails
   email_spec
   factory_girl_rails
+  i18n-active_record
   jbuilder (~> 2.5)
   launchy
   listen (>= 3.0.5, < 3.2)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -341,6 +341,8 @@ GEM
       sprockets (>= 2.8, < 4.0)
       sprockets-rails (>= 2.0, < 4.0)
       tilt (>= 1.1, < 3)
+    shoulda-callback-matchers (1.1.4)
+      activesupport (>= 3)
     simplecov (0.14.1)
       docile (~> 1.1.0)
       json (>= 1.8, < 3)
@@ -418,6 +420,7 @@ DEPENDENCIES
   rails-i18n (~> 5.0.0)
   rspec-rails
   sass-rails (~> 5.0)
+  shoulda-callback-matchers
   shoulda-matchers!
   spring
   spring-watcher-listen (~> 2.0.0)

--- a/app/admin/order.rb
+++ b/app/admin/order.rb
@@ -17,7 +17,7 @@ ActiveAdmin.register Order do
     link_to 'Generate Invoice', generate_invoice_order_path, method: :put
   end
 
-  action_item :generate_menu, only: :show, if: proc { !resource.has_menu? }do
+  action_item :generate_menu, only: :show, if: proc { !resource.has_menu? } do
     link_to 'Generate Menu', generate_menu_order_path, method: :put
   end
 
@@ -51,14 +51,14 @@ ActiveAdmin.register Order do
     column :id do |order|
       link_to 'Order: ' + order.id.to_s, admin_order_path(order)
     end
-      column :allergies
-      column :delivery_date
-      column :delivery_method
-      column :billing_name
-      column :allergies
-      column :boxes
-      column :status
-      actions
+    column :allergies
+    column :delivery_date
+    column :delivery_method
+    column :billing_name
+    column :allergies
+    column :boxes
+    column :status
+    actions
   end
 
 
@@ -72,7 +72,7 @@ ActiveAdmin.register Order do
         link_to 'Delete', admin_order_item_path(order_item), method: :delete, id: "delete_#{order_item.id}"
       end
 
-      column :Show do  |order_item|
+      column :Show do |order_item|
         link_to 'Show', admin_order_item_path(order_item)
       end
     end

--- a/app/admin/translation.rb
+++ b/app/admin/translation.rb
@@ -1,0 +1,53 @@
+ActiveAdmin.register Translation, as: 'Translation' do
+  menu label: 'Translations'
+  permit_params :locale, :key, :value, :interpolations, :is_proc
+
+  index do
+    selectable_column
+    column :locale
+    column :key
+    column :value
+    actions
+  end
+
+  show do
+    attributes_table do
+      row :key
+      row :value
+      row :locale
+    end
+  end
+
+  form do |f|
+    f.inputs do
+      f.input :locale, label: 'Language', as: :select, collection: LANGUAGES, include_blank: false
+      f.input :key, as: :select, collection: I18n.get_current_locale_keys, include_blank: false
+      f.input :value
+      f.actions
+    end
+  end
+
+  after_create do
+    I18n.backend.reload!
+  end
+
+
+  controller do
+
+    def create
+      super
+    end
+
+    def update
+      super
+      I18n.backend.reload!
+    end
+
+    def destroy
+      super
+      I18n.backend.reload!
+    end
+
+
+  end
+end

--- a/app/admin/translation.rb
+++ b/app/admin/translation.rb
@@ -26,28 +26,4 @@ ActiveAdmin.register Translation, as: 'Translation' do
       f.actions
     end
   end
-
-  after_create do
-    I18n.backend.reload!
-  end
-
-
-  controller do
-
-    def create
-      super
-    end
-
-    def update
-      super
-      I18n.backend.reload!
-    end
-
-    def destroy
-      super
-      I18n.backend.reload!
-    end
-
-
-  end
 end

--- a/app/models/translation.rb
+++ b/app/models/translation.rb
@@ -1,0 +1,2 @@
+class Translation < ApplicationRecord
+end

--- a/app/models/translation.rb
+++ b/app/models/translation.rb
@@ -1,2 +1,3 @@
 class Translation < ApplicationRecord
+
 end

--- a/app/models/translation.rb
+++ b/app/models/translation.rb
@@ -1,3 +1,6 @@
 class Translation < ApplicationRecord
 
+  validates_presence_of :value
+  validates_presence_of :locale
+  validates_presence_of :key
 end

--- a/app/models/translation.rb
+++ b/app/models/translation.rb
@@ -1,3 +1,10 @@
 class Translation < ApplicationRecord
   validates_presence_of :value, :locale, :key
+
+  after_touch :reload_i18n_backend
+
+  private
+  def reload_i18n_backend
+    I18n.backend.reload!
+  end
 end

--- a/app/models/translation.rb
+++ b/app/models/translation.rb
@@ -1,6 +1,3 @@
 class Translation < ApplicationRecord
-
-  validates_presence_of :value
-  validates_presence_of :locale
-  validates_presence_of :key
+  validates_presence_of :value, :locale, :key
 end

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -1,117 +1,103 @@
 <h1><%= t('main_title_order_form').html_safe %></h1>
 
 <p class="center"><%= t('intro_desc_order_form').html_safe %> </p>
-<p class="center"><%= t('minimum_order_form').html_safe %> </p>
-
 <br>
 <%= form_tag(orders_path) do %>
 
-    <% @categories.each do |category| %>
+  <% @categories.each do |category| %>
 
-      <h2><%= category.name.upcase %></h2>
-      <% if category.description != nil %>
-        <p class='center'> <%= category.description %> </p>
-      <% end %>
-
-      <% category.dish.each do |dish| %>
-         <div class="clear">
-          <div class="menu-item-form" id="dish_item_<%= dish.id %>">
-            <%= dish.price %> SEK <br>
-             <input class="q_text" type="text" name="dishes[dish_<%= dish.id %>]" value="" id="dish_<%= dish.id %>" placeholder="0" size="5"
-                    maxlength="4" data-minquantity="<%= dish.min_quantity %>" onblur="validateNumberOnBlur(this)"
-                    onkeyup="validateNumber(this)" onclick="validateNumber(this)" onchange="validateNumber(this)" >
-             <button class="q_button" type="button" name="button" onclick="decreaseNumber('dish_<%= dish.id %>')"> - </button>
-             <button class="q_button" type="button" name="button" onclick="increaseNumber('dish_<%= dish.id %>')"> + </button>
-            </div>
-            <div class="menu-item-title"><%= dish.name %></div>
-            <div>
-              <%= dish.description %>
-              <% if dish.min_quantity != 10 %>
-                <%= "#{t('minimum_order')}: #{dish.min_quantity.to_s}" %>
-              <% end %>
-            </div>
-          </div>
-      <% end %>
+    <h2><%= category.name.upcase %></h2>
+    <% if category.description != nil %>
+      <p class='center'> <%= category.description %> </p>
     <% end %>
 
-    <br>
+    <% category.dish.each do |dish| %>
+      <div class="clear">
+        <div class="menu-item-form" id="dish_item_<%= dish.id %>">
+          <%= dish.price %> SEK <br>
+          <input class="q_text" type="text" name="dishes[dish_<%= dish.id %>]" value="" id="dish_<%= dish.id %>" placeholder="0" size="5"
+                 maxlength="4" data-minquantity="<%= dish.min_quantity %>" onblur="validateNumberOnBlur(this)"
+                 onkeyup="validateNumber(this)" onclick="validateNumber(this)" onchange="validateNumber(this)">
+          <button class="q_button" type="button" name="button" onclick="decreaseNumber('dish_<%= dish.id %>')"> -
+          </button>
+          <button class="q_button" type="button" name="button" onclick="increaseNumber('dish_<%= dish.id %>')"> +
+          </button>
+        </div>
+        <div class="menu-item-title"><%= dish.name %></div>
+        <div>
+          <p><%= dish.description %></p>
+          <p><%= t('minimum_order', min_count: dish.min_quantity) %></p>
+        </div>
+      </div>
+    <% end %>
+  <% end %>
 
-    <div><%= submit_tag t('button.next'), class: 'button float-right' %></div>
+  <br>
+
+  <div><%= submit_tag t('button.next'), class: 'button float-right' %></div>
 
 <% end %>
 
 
-<script type="text/javascript" >
-    function validateNumber(object)
-    {
-        if (isNaN(object.value))
-        {
-            object.value = object.value.replace(/[^0-9]/g, '');
-        }
-
-        if (object.value == 0)
-        {
-            object.value = '';
-        }
-
+<script type="text/javascript">
+  function validateNumber(object) {
+    if (isNaN(object.value)) {
+      object.value = object.value.replace(/[^0-9]/g, '');
     }
 
-    function validateNumberOnBlur(object)
-    {
-      if (parseInt(object.value) < parseInt(object.dataset.minquantity) && object.value != '')
-      {
-        swal({
-          title: 'Oops...',
-          text: 'Minimum order quantity is ' + object.dataset.minquantity + '.',
-          type: 'warning',
-          showCancelButton: true,
-          confirmButtonColor: '#2dbc36',
-          confirmButtonText: 'Yes, please change to ' + object.dataset.minquantity + '.',
-          cancelButtonText: 'No, please change to 0.',
-          closeOnConfirm: true,
-          closeOnCancel: true,
-        },
-        function (isConfirm) {
-          if (isConfirm) {
+    if (object.value == 0) {
+      object.value = '';
+    }
+
+  }
+
+  function validateNumberOnBlur(object) {
+    if (parseInt(object.value) < parseInt(object.dataset.minquantity) && object.value != '') {
+      swal({
+            title: 'Oops...',
+            text: 'Minimum order quantity is ' + object.dataset.minquantity + '.',
+            type: 'warning',
+            showCancelButton: true,
+            confirmButtonColor: '#2dbc36',
+            confirmButtonText: 'Yes, please change to ' + object.dataset.minquantity + '.',
+            cancelButtonText: 'No, please change to 0.',
+            closeOnConfirm: true,
+            closeOnCancel: true,
+          },
+          function (isConfirm) {
+            if (isConfirm) {
               object.value = parseInt(object.dataset.minquantity);
-          } else {
+            } else {
               object.value = '';
-          }
-        });
-      }
-
-      if (object.value == 0)
-      {
-          object.value = '';
-      }
+            }
+          });
     }
 
-    function decreaseNumber(dishId)
-    {
-        var val = document.getElementById(dishId).value;
-        var min_val = document.getElementById(dishId).dataset.minquantity;
-
-        if ( val > min_val )
-        {
-            document.getElementById(dishId).value = val - 1;
-        } else if (val == min_val)
-        {
-            document.getElementById(dishId).value = '';
-        }
+    if (object.value == 0) {
+      object.value = '';
     }
+  }
 
-    function increaseNumber(dishId)
-    {
-        var val = parseInt(document.getElementById(dishId).value);
-        var min_val = parseInt(document.getElementById(dishId).dataset.minquantity);
+  function decreaseNumber(dishId) {
+    var val = document.getElementById(dishId).value;
+    var min_val = document.getElementById(dishId).dataset.minquantity;
 
-        if (val == '' || val < min_val - 1 || isNaN(val) )
-        {
-            document.getElementById(dishId).value = min_val;
-        } else if (val < 9999)
-        {
-            document.getElementById(dishId).value = val + 1;
-        }
+    if (val > min_val) {
+      document.getElementById(dishId).value = val - 1;
+    } else if (val == min_val) {
+      document.getElementById(dishId).value = '';
     }
+  }
+
+  function increaseNumber(dishId) {
+    var val = parseInt(document.getElementById(dishId).value);
+    var min_val = parseInt(document.getElementById(dishId).dataset.minquantity);
+
+    if (val == '' || val < min_val - 1 || isNaN(val)) {
+      document.getElementById(dishId).value = min_val;
+    } else if (val < 9999) {
+      document.getElementById(dishId).value = val + 1;
+    }
+  }
 
 </script>

--- a/config/initializers/locale.rb
+++ b/config/initializers/locale.rb
@@ -1,0 +1,13 @@
+require 'i18n/backend/active_record'
+
+Translation  = I18n::Backend::ActiveRecord::Translation
+
+if Translation.table_exists?
+  I18n.backend = I18n::Backend::ActiveRecord.new
+
+  I18n::Backend::ActiveRecord.send(:include, I18n::Backend::Memoize)
+  I18n::Backend::Simple.send(:include, I18n::Backend::Memoize)
+  I18n::Backend::Simple.send(:include, I18n::Backend::Pluralization)
+
+  I18n.backend = I18n::Backend::Chain.new(I18n::Backend::Simple.new, I18n.backend)
+end

--- a/config/initializers/locale.rb
+++ b/config/initializers/locale.rb
@@ -1,6 +1,5 @@
 require 'i18n/backend/active_record'
 LANGUAGES = [['English', 'en']]
-Translation = I18n::Backend::ActiveRecord::Translation
 
 if Translation.table_exists?
   I18n.backend = I18n::Backend::ActiveRecord.new
@@ -15,23 +14,17 @@ end
 
 module I18n
   class << self
-    def get_current_locale_keys(hsh = nil, parent = nil, ary = [])
-      current_locale = I18n.locale.to_s
+    def get_current_locale_keys(hsh = nil,
+                                parent = nil,
+                                ary = [],
+                                current_locale = I18n.locale.to_s)
       hsh = YAML.load_file("config/locales/#{current_locale}.yml") unless hsh
-      keys = hsh.keys
-      keys.each do |key|
-        if hsh.fetch(key).is_a?(Hash)
-          get_current_locale_keys(hsh.fetch(key), "#{key}", ary)
-        else
-          keys.each do |another|
-            if parent == current_locale
-              ary << "#{another}"
-            else
-              ary << "#{parent}.#{another}"
+      hsh.keys.each do |key|
+        hsh.fetch(key).is_a?(Hash) ?
+            get_current_locale_keys(hsh.fetch(key), key, ary) :
+            hsh.keys.each do |another|
+              (parent == current_locale) ? ary << another : ary << "#{parent}.#{another}"
             end
-
-          end
-        end
       end
       ary.uniq
     end

--- a/config/initializers/locale.rb
+++ b/config/initializers/locale.rb
@@ -1,13 +1,39 @@
 require 'i18n/backend/active_record'
-
-Translation  = I18n::Backend::ActiveRecord::Translation
+LANGUAGES = [['English', 'en']]
+Translation = I18n::Backend::ActiveRecord::Translation
 
 if Translation.table_exists?
   I18n.backend = I18n::Backend::ActiveRecord.new
 
   I18n::Backend::ActiveRecord.send(:include, I18n::Backend::Memoize)
+  I18n::Backend::ActiveRecord.send(:include, I18n::Backend::Flatten)
   I18n::Backend::Simple.send(:include, I18n::Backend::Memoize)
   I18n::Backend::Simple.send(:include, I18n::Backend::Pluralization)
 
-  I18n.backend = I18n::Backend::Chain.new(I18n::Backend::Simple.new, I18n.backend)
+  I18n.backend = I18n::Backend::Chain.new(I18n.backend, I18n::Backend::Simple.new)
+end
+
+module I18n
+  class << self
+    def get_current_locale_keys(hsh = nil, parent = nil, ary = [])
+      current_locale = I18n.locale.to_s
+      hsh = YAML.load_file("config/locales/#{current_locale}.yml") unless hsh
+      keys = hsh.keys
+      keys.each do |key|
+        if hsh.fetch(key).is_a?(Hash)
+          get_current_locale_keys(hsh.fetch(key), "#{key}", ary)
+        else
+          keys.each do |another|
+            if parent == current_locale
+              ary << "#{another}"
+            else
+              ary << "#{parent}.#{another}"
+            end
+
+          end
+        end
+      end
+      ary.uniq
+    end
+  end
 end

--- a/config/initializers/locale.rb
+++ b/config/initializers/locale.rb
@@ -22,8 +22,8 @@ module I18n
       hsh.keys.each do |key|
         hsh.fetch(key).is_a?(Hash) ?
             get_current_locale_keys(hsh.fetch(key), key, ary) :
-            hsh.keys.each do |another|
-              (parent == current_locale) ? ary << another : ary << "#{parent}.#{another}"
+            hsh.keys.each do |child|
+              (parent == current_locale) ? ary << child : ary << "#{parent}.#{child}"
             end
       end
       ary.uniq

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -4,7 +4,6 @@ en:
                           organic ingredients as far as possibly possible. Our packaging is 100%
                           compostable and our delivery service is made by cargo bike. All our food and
                           desserts are made without white refined sugar and no added gluten."
-  minimum_order_form: "Minimum amount per dish to order - 10 servings."
   minimum_order: "Minimum order of %{min_count} portions."
   pickup: "We’d like to pick up the order<br> ourselves at Tegelbacken 4A"
   delivery: "We'd like the order to be delivered <br> directly to us by cargo bike."

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -5,7 +5,7 @@ en:
                           compostable and our delivery service is made by cargo bike. All our food and
                           desserts are made without white refined sugar and no added gluten."
   minimum_order_form: "Minimum amount per dish to order - 10 servings."
-  minimum_order: "Minimum order"
+  minimum_order: "Minimum order of %{min_count} portions."
   pickup: "We’d like to pick up the order<br> ourselves at Tegelbacken 4A"
   delivery: "We'd like the order to be delivered <br> directly to us by cargo bike."
   allergy_header: "Allergies – No Problem!"

--- a/db/migrate/20170916065934_create_translations.rb
+++ b/db/migrate/20170916065934_create_translations.rb
@@ -1,0 +1,13 @@
+class CreateTranslations < ActiveRecord::Migration[5.1]
+  def change
+    create_table :translations do |t|
+      t.string :locale
+      t.string :key
+      t.text :value
+      t.text :interpolations
+      t.boolean :is_proc, default: false
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170914155715) do
+ActiveRecord::Schema.define(version: 20170916065934) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -115,6 +115,16 @@ ActiveRecord::Schema.define(version: 20170914155715) do
     t.string "billing_phone"
     t.string "billing_email"
     t.datetime "due_date"
+  end
+
+  create_table "translations", force: :cascade do |t|
+    t.string "locale"
+    t.string "key"
+    t.text "value"
+    t.text "interpolations"
+    t.boolean "is_proc", default: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
 
   add_foreign_key "attachments", "orders"

--- a/features/add_dishes_to_order.feature
+++ b/features/add_dishes_to_order.feature
@@ -6,10 +6,13 @@ Feature: Allow end user to select dishes and quantities to order.
 
   Background:
     Given the following dishes exist:
-      | name         | description             | price | min_quantity |
-      | Dish 1       | Description for Dish 1  | 100   |  10          |
-      | Dish 2       | Description for Dish 2  | 200   |  20          |
-      | Dish 3       | Description for Dish 3  | 300   |  1           |
+      | name   | description            | price | min_quantity |
+      | Dish 1 | Description for Dish 1 | 100   | 10           |
+      | Dish 2 | Description for Dish 2 | 200   | 20           |
+      | Dish 3 | Description for Dish 3 | 300   | 1            |
+
+    And there are no custom translations
+
 
   Scenario: User can manipulate quantity with + and - buttons
     When I go to the landing page

--- a/features/admin_updates_minimum_order_message.feature
+++ b/features/admin_updates_minimum_order_message.feature
@@ -18,11 +18,11 @@ Feature: Admin adds custom translations
   Scenario: Admin updates minimum order message
     Given I click on menu item "Translations"
     And I press "New Translation"
-    And I select "minimum_order_form" from "Key"
-    And I fill in "Value" with "You can order whatever amount you want"
+    And I select "minimum_order" from "Key"
+    And I fill in "Value" with "Minimum order for this dish is %{min_count} portions."
     And I press "Create Translation"
     And I go to the landing page
-    Then I should see "You can order whatever amount you want"
+    Then I should see "Minimum order for this dish is 10 portions."
 
 
   Scenario: Admin updates customer confirmation text

--- a/features/admin_updates_minimum_order_message.feature
+++ b/features/admin_updates_minimum_order_message.feature
@@ -1,4 +1,4 @@
-Feature: Admin updates minimum order message
+Feature: Admin adds custom translations
   As a Gigafood
   In order to have the customer to notice order details on servings
   We need to change or remove specs about minimum number of serving
@@ -8,6 +8,8 @@ Feature: Admin updates minimum order message
     Given the following dishes exist:
       | name   | description            | price | min_quantity |
       | Dish 1 | Description for Dish 1 | 100   | 10           |
+
+    And there are no custom translations
 
     And an admin exists with email "admin@example.com" and password "password"
     And I'm loged in as admin user "admin@example.com"

--- a/features/admin_updates_minimum_order_message.feature
+++ b/features/admin_updates_minimum_order_message.feature
@@ -4,17 +4,41 @@ Feature: Admin updates minimum order message
   We need to change or remove specs about minimum number of serving
 
   Background:
-    Given an admin exists with email "admin@example.com" and password "password"
+
+    Given the following dishes exist:
+      | name   | description            | price | min_quantity |
+      | Dish 1 | Description for Dish 1 | 100   | 10           |
+
+    And an admin exists with email "admin@example.com" and password "password"
     And I'm loged in as admin user "admin@example.com"
     And I go to the dashboard
 
-    Scenario: Admin updates minimum order message
-      Given I click on "Translations"
-      And I press "New Translation"
-      And I select "minimum_order_form" from "Key"
-      And I fill in "Value" with "You can order whatever amount you want"
-      And I press "Create Translation"
-      And I go to the landing page
-      Then I should see "You can order whatever amount you want"
+  Scenario: Admin updates minimum order message
+    Given I click on menu item "Translations"
+    And I press "New Translation"
+    And I select "minimum_order_form" from "Key"
+    And I fill in "Value" with "You can order whatever amount you want"
+    And I press "Create Translation"
+    And I go to the landing page
+    Then I should see "You can order whatever amount you want"
+
+
+  Scenario: Admin updates customer confirmation text
+    Given I click on menu item "Translations"
+    And I press "New Translation"
+    And I select "thank_you_title" from "Key"
+    And I fill in "Value" with "Awesome dude!"
+    And I press "Create Translation"
+    And I click on menu item "Translations"
+    And I press "New Translation"
+    And I select "thank_you_message" from "Key"
+    And I fill in "Value" with "We will take a look and get back to you"
+    And I press "Create Translation"
+    And I go to the landing page
+    And I click on + for "Dish 1"
+    And I click on "Next"
+    And I fill in all relevant fields and submit the order
+    Then I should see "Awesome dude!"
+    Then I should see "We will take a look and get back to you"
 
 

--- a/features/admin_updates_minimum_order_message.feature
+++ b/features/admin_updates_minimum_order_message.feature
@@ -1,0 +1,20 @@
+Feature: Admin updates minimum order message
+  As a Gigafood
+  In order to have the customer to notice order details on servings
+  We need to change or remove specs about minimum number of serving
+
+  Background:
+    Given an admin exists with email "admin@example.com" and password "password"
+    And I'm loged in as admin user "admin@example.com"
+    And I go to the dashboard
+
+    Scenario: Admin updates minimum order message
+      Given I click on "Translations"
+      And I press "New Translation"
+      And I select "minimum_order_form" from "Key"
+      And I fill in "Value" with "You can order whatever amount you want"
+      And I press "Create Translation"
+      And I go to the landing page
+      Then I should see "You can order whatever amount you want"
+
+

--- a/features/step_definitions/generic_steps.rb
+++ b/features/step_definitions/generic_steps.rb
@@ -46,6 +46,6 @@ Then /^(?:|I )should be on (.+)$/ do |page_name|
   expect(URI.parse(current_url).path).to eq path_to page_name
 end
 
-Then(/^I select "([^"]*)" from "([^"]*)"$/) do |arg1, arg2|
-  select "Starter", :from => "dish_category_id"
+Then(/^I select "([^"]*)" from "([^"]*)"$/) do |value, selector|
+  select value, from: selector
 end

--- a/features/step_definitions/generic_steps.rb
+++ b/features/step_definitions/generic_steps.rb
@@ -49,3 +49,10 @@ end
 Then(/^I select "([^"]*)" from "([^"]*)"$/) do |value, selector|
   select value, from: selector
 end
+
+
+Given(/^I click on menu item "([^"]*)"$/) do |element_value|
+  within '#header' do
+    click_link_or_button element_value
+  end
+end

--- a/features/step_definitions/order_steps.rb
+++ b/features/step_definitions/order_steps.rb
@@ -45,3 +45,28 @@ Given(/^"([^"]*)"'s order contains no items$/) do |billing_name|
   @order = Order.find_by(billing_name: billing_name)
   @order.clear if @order.shopping_cart_items
 end
+
+
+And(/^I fill in all relevant fields and submit the order$/) do
+  steps %q{
+      And I fill in Delivery Date with "2017-11-10 12:00"
+      And I fill in "Delivery Name" with "Hungry corp Inc"
+      And I fill in "Delivery Address" with "Street 42"
+      And I fill in "Delivery_Postal_Code" with "123 45"
+      And I fill in "Delivery City" with "Town"
+      And I fill in "Delivery Floor" with "3"
+      And I fill in "Delivery Door Code" with "1111"
+      And I fill in "Delivery Contact Name" with "John Doe"
+      And I fill in "Delivery Contact Phone" with "555 123 45 67"
+      And I fill in "Billing Name" with "John Doe"
+      And I fill in "Billing Company" with "Hungry corp Inc"
+      And I fill in "Billing Organisation Number" with "19210713-1444"
+      And I fill in "Billing Address" with "Street 42"
+      And I fill in "Billing_Postal_Code" with "123 45"
+      And I fill in "Billing City" with "Town"
+      And I fill in "Billing Contact Phone" with "555 123 55 11"
+      And I fill in "Billing email" with "invoice@hungrycorp.com"
+      And I click on "Submit Order"
+
+  }
+end

--- a/features/step_definitions/translation_steps.rb
+++ b/features/step_definitions/translation_steps.rb
@@ -1,3 +1,4 @@
 And(/^there are no custom translations$/) do
   Translation.destroy_all
+  I18n.backend.reload!
 end

--- a/features/step_definitions/translation_steps.rb
+++ b/features/step_definitions/translation_steps.rb
@@ -1,0 +1,3 @@
+And(/^there are no custom translations$/) do
+  Translation.destroy_all
+end

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -20,3 +20,4 @@ World Warden::Test::Helpers
 After { Warden.test_reset! }
 
 Capybara.javascript_driver = :poltergeist
+

--- a/features/user_commit_order.feature
+++ b/features/user_commit_order.feature
@@ -9,6 +9,9 @@ Feature: Allow end user to commit order
       | name   | description            | price | min_quantity |
       | Dish 1 | Description for Dish 1 | 100   | 10           |
 
+    And there are no custom translations
+
+
   Scenario: User can manipulate quantity with + and - buttons
     When I go to the landing page
     And I click on + for "Dish 1"

--- a/features/view_dishes.feature
+++ b/features/view_dishes.feature
@@ -19,10 +19,10 @@ Feature: List dishes on landing page
     When I go to the landing page
     Then I should see "MAIN"
     Then I should see "STARTER"
-    Then I should see "Minimum order: 20"
     Then I should see "<name>"
     Then I should see "<description>"
     Then I should see "<price>"
+    Then I should see "Minimum order of <min_quantity> portions."
 
     Examples:
       | name         | description             | price | min_quantity |

--- a/spec/factories/translations.rb
+++ b/spec/factories/translations.rb
@@ -1,0 +1,9 @@
+FactoryGirl.define do
+  factory :translation do
+    locale "MyString"
+    key "MyString"
+    value "MyText"
+    interpolations "MyText"
+    is_proc false
+  end
+end

--- a/spec/factories/translations.rb
+++ b/spec/factories/translations.rb
@@ -1,9 +1,9 @@
 FactoryGirl.define do
   factory :translation do
-    locale "MyString"
-    key "MyString"
-    value "MyText"
-    interpolations "MyText"
+    locale :en
+    key 'my_key'
+    value 'My Vamue'
+    interpolations ['']
     is_proc false
   end
 end

--- a/spec/models/translation_spec.rb
+++ b/spec/models/translation_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Translation, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/models/translation_spec.rb
+++ b/spec/models/translation_spec.rb
@@ -17,6 +17,6 @@ RSpec.describe Translation, type: :model do
   it { is_expected.to validate_presence_of :locale }
 
 
-
+  it { is_expected.to callback(:reload_i18n_backend).after(:touch) }
 
 end

--- a/spec/models/translation_spec.rb
+++ b/spec/models/translation_spec.rb
@@ -1,5 +1,22 @@
 require 'rails_helper'
 
 RSpec.describe Translation, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
+  it 'should have valid Factory' do
+    expect(FactoryGirl.create(:translation)).to be_valid
+  end
+
+  it { is_expected.to have_db_column :id }
+  it { is_expected.to have_db_column :key }
+  it { is_expected.to have_db_column :value }
+  it { is_expected.to have_db_column :locale }
+  it { is_expected.to have_db_column :interpolations }
+  it { is_expected.to have_db_column :is_proc }
+
+  it { is_expected.to validate_presence_of :key }
+  it { is_expected.to validate_presence_of :value }
+  it { is_expected.to validate_presence_of :locale }
+
+
+
+
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -21,5 +21,6 @@ RSpec.configure do |config|
   config.filter_rails_from_backtrace!
   config.include FactoryGirl::Syntax::Methods
   config.include Paperclip::Shoulda::Matchers
+  config.include Shoulda::Callback::Matchers::ActiveModel
 
 end


### PR DESCRIPTION
### PT Story: https://www.pivotaltracker.com/story/show/151123172 (NOT ESTIMATED)
Also deals with: https://www.pivotaltracker.com/story/show/151124730

Changes proposed in this PR:
* adds interface for adding custom translations to ActiveAdmin
* adds [I18n active record gem](https://rubygems.org/gems/i18n-active_record)
* adds matchers for [testing ActiveModel callbacks](https://rubygems.org/gems/shoulda-callback-matchers)
* adds custom `get_current_locale_keys` method to populate select field
* adds mechanism for checking the locale yml file if no translation in db exist
* makes sure I18n reloads after each update or destroy in test env by adding a step definition that clears the `translations` table and reloads I18n.backend
* updates dish listing (on landing page) with minimum order per dish 


**TODO: In separate features we should consider how to improve the UX for non-tech admins. Perhaps create a list of keys for admin to reference when creating translations OR a seeds file with current translations.**