### PR TITLE
Display Dishes in specific order

### DIFF
--- a/app/admin/dish.rb
+++ b/app/admin/dish.rb
@@ -1,3 +1,3 @@
 ActiveAdmin.register Dish do
-  permit_params :name, :description, :price, :min_quantity, :category_id
+  permit_params :name, :description, :price, :min_quantity, :category_id, :sort_key
 end

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -13,7 +13,7 @@
         <p class='center'> <%= category.description %> </p>
       <% end %>
 
-      <% category.dish.each do |dish| %>
+      <% category.dish.order(:sort_key).all.each do |dish| %>
          <div class="clear">
           <div class="menu-item-form" id="dish_item_<%= dish.id %>">
             <%= dish.price %> SEK <br>

--- a/db/migrate/20170915233634_add_sort_key_to_dish.rb
+++ b/db/migrate/20170915233634_add_sort_key_to_dish.rb
@@ -1,0 +1,5 @@
+class AddSortKeyToDish < ActiveRecord::Migration[5.1]
+  def change
+    add_column :dishes, :sort_key, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170914155715) do
+ActiveRecord::Schema.define(version: 20170915233634) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -74,6 +74,7 @@ ActiveRecord::Schema.define(version: 20170914155715) do
     t.datetime "updated_at", null: false
     t.integer "min_quantity", default: 10
     t.bigint "category_id"
+    t.integer "sort_key"
     t.index ["category_id"], name: "index_dishes_on_category_id"
   end
 

--- a/features/step_definitions/dishes_steps.rb
+++ b/features/step_definitions/dishes_steps.rb
@@ -34,3 +34,11 @@ end
 Then(/^I should see the button "([^"]*)"$/) do |button_name|
   expect(page).to have_button(button_name)
 end
+
+Then(/^Starter should be displayed before Main$/) do
+  expect(page).to have_content(/Starter(.|\n)+?Main/i)
+end
+
+Then(/^Tomato should be displayed before Corn last$/) do
+  expect(page).to have_content(/Tomato(.|\n)+?Corn/i)
+end

--- a/features/step_definitions/dishes_steps.rb
+++ b/features/step_definitions/dishes_steps.rb
@@ -39,6 +39,6 @@ Then(/^Starter should be displayed before Main$/) do
   expect(page).to have_content(/Starter(.|\n)+?Main/i)
 end
 
-Then(/^Tomato should be displayed before Corn last$/) do
+Then(/^Tomato should be displayed before Corn$/) do
   expect(page).to have_content(/Tomato(.|\n)+?Corn/i)
 end

--- a/features/view_dishes.feature
+++ b/features/view_dishes.feature
@@ -10,10 +10,10 @@ Feature: List dishes on landing page
       | Starter | Description for category 1 | 1        |
 
     And the following dishes exist:
-      | name   | description            | price | min_quantity | category |
-      | Dish 1 | Description for Dish 1 | 100   | 10           | Starter  |
-      | Dish 2 | Description for Dish 2 | 200   | 10           | Main     |
-      | Dish 3 | Description for Dish 3 | 300   | 20           | Main     |
+      | name        | description            | price | min_quantity | category | sort_key |
+      | Start first | Description for Dish 1 | 100   | 10           | Starter  | 1        |
+      | Corn        | Description for Dish 2 | 200   | 10           | Main     | 2        |
+      | Tomato      | Description for Dish 3 | 300   | 20           | Main     | 1        |
 
   Scenario Outline: View a list of dishes on the screen
     When I go to the landing page
@@ -25,7 +25,13 @@ Feature: List dishes on landing page
     Then I should see "<price>"
 
     Examples:
-      | name         | description             | price | min_quantity |
-      | Dish 1       | Description for Dish 1  | 100   |  10          |
-      | Dish 2       | Description for Dish 2  | 200   |  10          |
-      | Dish 3       | Description for Dish 3  | 300   |  10          |
+      | name        | description            | price |
+      | Start first | Description for Dish 1 | 100   |
+      | Corn        | Description for Dish 2 | 200   |
+      | Tomato      | Description for Dish 3 | 300   |
+
+    Scenario:
+      When I go to the landing page
+      Then Starter should be displayed before Main
+      And Tomato should be displayed before Corn last
+

--- a/features/view_dishes.feature
+++ b/features/view_dishes.feature
@@ -11,7 +11,7 @@ Feature: List dishes on landing page
 
     And the following dishes exist:
       | name        | description            | price | min_quantity | category | sort_key |
-      | Start first | Description for Dish 1 | 100   | 10           | Starter  | 1        |
+      | Start       | Description for Dish 1 | 100   | 10           | Starter  | 1        |
       | Corn        | Description for Dish 2 | 200   | 10           | Main     | 2        |
       | Tomato      | Description for Dish 3 | 300   | 20           | Main     | 1        |
 
@@ -26,12 +26,12 @@ Feature: List dishes on landing page
 
     Examples:
       | name        | description            | price |
-      | Start first | Description for Dish 1 | 100   |
+      | Start       | Description for Dish 1 | 100   |
       | Corn        | Description for Dish 2 | 200   |
       | Tomato      | Description for Dish 3 | 300   |
 
     Scenario:
       When I go to the landing page
       Then Starter should be displayed before Main
-      And Tomato should be displayed before Corn last
+      And Tomato should be displayed before Corn
 

--- a/spec/factories/dishes.rb
+++ b/spec/factories/dishes.rb
@@ -4,5 +4,6 @@ FactoryGirl.define do
     description "dish features"
     price 1
     category
+    sort_key 1
   end
 end


### PR DESCRIPTION
## PT: https://www.pivotaltracker.com/story/show/150943048 ##

-Add sort_key to Dish model
-Display Dishes order by sort key on menu page